### PR TITLE
So long track names and music names text scroll if they are too long

### DIFF
--- a/src/public/scripts/playlist.js
+++ b/src/public/scripts/playlist.js
@@ -1,0 +1,14 @@
+const containers = document.getElementsByClassName("marquee-container");
+var i = Array.from(containers);
+
+Array.from(containers).forEach((element) => {
+  console.log("Container", element);
+  const textElements = element.querySelectorAll(".marquee-text");
+
+  textElements.forEach((text) => {
+    console.log("Text", text);
+    if (text.scrollWidth > element.clientWidth) {
+      text.style.animation = "marquee 10s linear infinite";
+    }
+  });
+});

--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -159,6 +159,30 @@ button.applied {
   }
 }
 
+.marquee-container {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.marquee-text {
+  white-space: nowrap;
+  overflow: hidden;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-self: space-between;
+  gap: 2rem;
+}
+
+@keyframes marquee {
+  0% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
 /* Music Player */
 .music-player-container {
   position: fixed;

--- a/src/views/partials/playlist.ejs
+++ b/src/views/partials/playlist.ejs
@@ -6,3 +6,4 @@
   </li>
   <% } %>
 </ul>
+<script src="/scripts/playlist.js"></script>

--- a/src/views/partials/track/track.ejs
+++ b/src/views/partials/track/track.ejs
@@ -8,9 +8,9 @@
       trackName: track.name, 
       artistName: track.artists.map(artist => artist.name).join(', ')
     }); %>
-  <div class="track-information">
-    <div class="track-title"><%= track.name %></div>
-    <div class="track-artist">
+  <div class="track-information marquee-container">
+    <div class="track-title marquee-text"><%= track.name %></div>
+    <div class="track-artist marquee-text">
       <%= track.artists.map(artist => artist.name).join(', ') %>
     </div>
   </div>


### PR DESCRIPTION
# Background
Songs with very long names were hard to read. They distorted the shape of the track items.

# 🎯 Goal - Scroll long text on a single line
Apply a kind of marquee effect on long text. 

# Feature Impacted
- Playlist Tracks
   - Track Name
   - Artist Name