### PR TITLE
feat: Eagerly load and cache playlists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "helmet": "^7.1.0",
+        "lru-cache": "^10.2.0",
         "node-cron": "^3.0.3",
         "redoc": "^2.1.3",
         "yamljs": "^0.3.0"
@@ -802,6 +803,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -5375,12 +5385,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/lunr": {
@@ -6030,15 +6039,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
       }
     },
     "node_modules/path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "helmet": "^7.1.0",
+    "lru-cache": "^10.2.0",
     "node-cron": "^3.0.3",
     "redoc": "^2.1.3",
     "yamljs": "^0.3.0"

--- a/src/music/playlists/__tests__/playlists.cache.tests.ts
+++ b/src/music/playlists/__tests__/playlists.cache.tests.ts
@@ -1,0 +1,75 @@
+import { PlaylistCache } from "../playlists.cache";
+import {
+  getExamplePlaylist,
+  populateWithTracks,
+} from "../../testingUtils/music.test.utils";
+
+describe("Playlist Cache", () => {
+  describe("Given: there are tracks in the database", () => {
+    beforeAll(async () => {
+      await populateWithTracks();
+    });
+
+    describe("basic api", () => {
+      it("does not return an item is not in the cache", () => {
+        const cache = new PlaylistCache();
+        expect(cache.get("foo")).toBeUndefined();
+      });
+
+      it("can set and get an item", async () => {
+        const cache = new PlaylistCache();
+        const playlist = await getExamplePlaylist();
+        cache.set("foo", playlist);
+        expect(cache.get("foo")).toEqual(playlist);
+      });
+
+      it("can delete an item", async () => {
+        const cache = new PlaylistCache();
+        const playlist = await getExamplePlaylist();
+        cache.set("foo", playlist);
+        cache.delete("foo");
+        expect(cache.get("foo")).toBeUndefined();
+
+        // only the deleted item should be removed
+        cache.set("foo", playlist);
+        cache.set("baz", playlist);
+        cache.delete("foo");
+        expect(cache.get("foo")).toBeUndefined();
+        expect(cache.get("baz")).toEqual(playlist);
+      });
+    });
+
+    describe("cache size limit", () => {
+      it("fails if the cache size is less than 1", () => {
+        expect(() => new PlaylistCache(0)).toThrow();
+      });
+
+      it("does not add more items than the cache size", async () => {
+        const playlist = await getExamplePlaylist();
+        const numberOfTracks = playlist.tracks.items.length;
+        const cache = new PlaylistCache(numberOfTracks - 2);
+        cache.set("foo", playlist);
+        expect(cache.get("foo")).toBeUndefined();
+      });
+
+      it("removes the oldest item when the cache is full", async () => {
+        const playlist = await getExamplePlaylist();
+        const numberOfTracks = playlist.tracks.items.length;
+
+        const cache = new PlaylistCache(numberOfTracks * 2);
+        cache.set("foo", playlist);
+        cache.set("bar", playlist);
+        cache.set("baz", playlist);
+
+        expect(cache.get("foo")).toBeUndefined();
+        expect(cache.get("bar")).toEqual(playlist);
+        expect(cache.get("baz")).toEqual(playlist);
+
+        cache.set("foo", playlist);
+        expect(cache.get("foo")).toEqual(playlist);
+        expect(cache.get("bar")).toBeUndefined();
+        expect(cache.get("baz")).toEqual(playlist);
+      });
+    });
+  });
+});

--- a/src/music/playlists/playlists.cache.ts
+++ b/src/music/playlists/playlists.cache.ts
@@ -33,22 +33,8 @@ export class PlaylistCache {
    * @param {string | undefined} alternativeKey - The alternative key. This parameter is optional.
    * @returns {Playlist | undefined} The playlist if found, or undefined if not found.
    */
-  get(
-    key: string,
-    alternativeKey: string | undefined = undefined
-  ): Playlist | undefined {
-    const primaryKeyResult = this.cache.get(key);
-    if (primaryKeyResult) {
-      return primaryKeyResult;
-    }
-
-    // if the primary key is not found, try the alternative key
-    if (alternativeKey) {
-      const alternativeKeyResult = this.cache.get(alternativeKey);
-      if (alternativeKeyResult) {
-        return alternativeKeyResult;
-      }
-    }
+  get(key: string): Playlist | undefined {
+    return this.cache.get(key);
   }
 
   set(key: string, playlist: Playlist) {

--- a/src/music/playlists/playlists.cache.ts
+++ b/src/music/playlists/playlists.cache.ts
@@ -1,0 +1,61 @@
+import { LRUCache } from "lru-cache";
+import { Playlist, PreferenceType } from "./playlists.types";
+
+function sizeCalculation(playlist: Playlist) {
+  return playlist.tracks.items.length;
+}
+
+export class PlaylistCache {
+  private cache: LRUCache<string, any>;
+
+  constructor(maxNumTracks: number = 1000) {
+    this.cache = new LRUCache({
+      maxSize: maxNumTracks,
+      sizeCalculation: sizeCalculation,
+      ttl: 1000 * 60 * 60 * 12, // half a day
+      allowStale: false, // we will not return a stale playlist
+    });
+  }
+
+  static createKey(
+    userIds: [number, number],
+    preference: PreferenceType
+  ): string {
+    return [...userIds, preference].join("-");
+  }
+
+  /**
+   * Retrieves a playlist from the cache using a primary key or an optional alternative key.
+   *
+   * This function first tries to retrieve the playlist using the primary key. If the playlist is not found, it tries to retrieve the playlist using the alternative key.
+   *
+   * @param {string} key - The primary key.
+   * @param {string | undefined} alternativeKey - The alternative key. This parameter is optional.
+   * @returns {Playlist | undefined} The playlist if found, or undefined if not found.
+   */
+  get(
+    key: string,
+    alternativeKey: string | undefined = undefined
+  ): Playlist | undefined {
+    const primaryKeyResult = this.cache.get(key);
+    if (primaryKeyResult) {
+      return primaryKeyResult;
+    }
+
+    // if the primary key is not found, try the alternative key
+    if (alternativeKey) {
+      const alternativeKeyResult = this.cache.get(alternativeKey);
+      if (alternativeKeyResult) {
+        return alternativeKeyResult;
+      }
+    }
+  }
+
+  set(key: string, playlist: Playlist) {
+    this.cache.set(key, playlist);
+  }
+
+  delete(key: string) {
+    this.cache.delete(key);
+  }
+}

--- a/src/music/playlists/playlists.service.ts
+++ b/src/music/playlists/playlists.service.ts
@@ -48,15 +48,19 @@ export async function getPlaylist(
   preferenceType: PreferenceType,
 ): Promise<Playlist> {
   const key = PlaylistCache.createKey([user1.id, user2.id], preferenceType);
+  const cachedPlaylist = playlistCache.get(key);
+
+  if (cachedPlaylist) {
+    return cachedPlaylist;
+  }
+
   const alternativeKey = PlaylistCache.createKey(
     [user2.id, user1.id],
     reversePreferenceType(preferenceType),
   );
-
-  const cachedPlaylist = playlistCache.get(key, alternativeKey);
-
-  if (cachedPlaylist) {
-    return cachedPlaylist;
+  const cachedPlaylistInverse = playlistCache.get(alternativeKey);
+  if (cachedPlaylistInverse) {
+    return cachedPlaylistInverse;
   }
 
   const tracksMatchingPreferenceType = await getTrackIdsByPreferenceType(

--- a/src/music/playlists/playlists.service.ts
+++ b/src/music/playlists/playlists.service.ts
@@ -1,10 +1,22 @@
 import { PrismaClient } from "@prisma/client";
 
 import { UserWithId } from "../../users/users.types";
-import { TrackWithId } from "../music.types";
-import { PreferenceType, Playlist } from "./playlists.types";
+import {
+  Playlist,
+  PreferenceType,
+  reversePreferenceType,
+} from "./playlists.types";
+import { PlaylistCache } from "./playlists.cache";
 
 const prisma = new PrismaClient();
+
+const MAX_NUM_USERS = 10;
+const PLAYLISTS_PER_USER = 3;
+const MAX_TRACKS_PER_PLAYLIST = 50;
+const MAX_NUM_TRACKS =
+  MAX_NUM_USERS * PLAYLISTS_PER_USER * MAX_TRACKS_PER_PLAYLIST;
+
+const playlistCache = new PlaylistCache(MAX_NUM_TRACKS);
 
 type LikedTracksQueryResponse = {
   trackId: number;
@@ -12,15 +24,45 @@ type LikedTracksQueryResponse = {
   user2Count: number;
 }[];
 
+/**
+ * This function retrieves a playlist for two users based on their shared music preferences.
+ *
+ * @remarks
+ * The system first checks a playlist cache to see if a playlist for the given users
+ * and preference type already exists. If a playlist is found in the cache, the function
+ * returns the playlist. If not, the function retrieves the tracks that match the users'
+ * shared music preferences from the database and creates a playlist object.
+ * The playlist object is then added to the cache.
+ *
+ * @param {UserWithId} user1 - The first user.
+ * @param {UserWithId} user2 - The second user.
+ * @param {PreferenceType} preferenceType - The type of music preference to consider when generating the playlist.
+ *
+ * @returns {Promise<Playlist>} A Promise that resolves to a Playlist object. The Playlist object contains tracks that match the users' shared music preferences.
+ *
+ * @throws {Error} If there is an error retrieving the tracks from the database or the cache.
+ */
 export async function getPlaylist(
   user1: UserWithId,
   user2: UserWithId,
-  preferenceType: PreferenceType
+  preferenceType: PreferenceType,
 ): Promise<Playlist> {
+  const key = PlaylistCache.createKey([user1.id, user2.id], preferenceType);
+  const alternativeKey = PlaylistCache.createKey(
+    [user2.id, user1.id],
+    reversePreferenceType(preferenceType),
+  );
+
+  const cachedPlaylist = playlistCache.get(key, alternativeKey);
+
+  if (cachedPlaylist) {
+    return cachedPlaylist;
+  }
+
   const tracksMatchingPreferenceType = await getTrackIdsByPreferenceType(
     user1,
     user2,
-    preferenceType
+    preferenceType,
   );
 
   const tracks = (
@@ -45,18 +87,65 @@ export async function getPlaylist(
     })
   ).map((track) => ({ ...track, imageUrl: track.imageUrl || undefined }));
 
-  return {
+  const playlist: Playlist = {
     tracks: { items: tracks },
   };
+
+  playlistCache.set(key, playlist);
+
+  return playlist;
 }
 
+/**
+ * Caches all playlists for two users based on their preference types.
+ *
+ * This function iterates over each preference type ("BOTH", "USER1-ONLY", "USER2-ONLY") and calls the `getPlaylist` function for each type.
+ * The `getPlaylist` function is assumed to cache the playlist for the given users and preference type.
+ *
+ * @param {UserWithId} user1 - The first user.
+ * @param {UserWithId} user2 - The second user.
+ * @r
+ */
+export async function preLoadAllPlaylists(
+  user1: UserWithId,
+  user2: UserWithId,
+): Promise<void> {
+  const preferenceTypes: PreferenceType[] = [
+    "BOTH",
+    "USER1-ONLY",
+    "USER2-ONLY",
+  ];
+
+  console.time(`Preloading playlists for ${user1.id} and ${user2.id}`);
+  return Promise.all(
+    preferenceTypes.map(async (preferenceType) => {
+      await getPlaylist(user1, user2, preferenceType);
+    }),
+  ).then(() => {
+    console.timeEnd(`Preloading playlists for ${user1.id} and ${user2.id}`);
+  }); // Do nothing. The .then() is necessary to return a Promise<void> instead of Promise<void[]>
+}
+
+/**
+ * This function retrieves a playlist for two users based on their shared music preferences.
+ *
+ * @param {UserWithId} user1 - The first user.
+ * @param {UserWithId} user2 - The second user.
+ * @param {PreferenceType} preferenceType - The type of music preference to consider when
+ * generating the playlist.
+ *
+ * @returns {Promise<Playlist>} A Promise that resolves to a Playlist object. The Playlist
+ * object contains tracks that match the users' shared music preferences.
+ *
+ * @throws {Error} If there is an error retrieving the tracks from the database or the cache.
+ */
 const getTrackIdsByPreferenceType = async (
   user1: UserWithId,
   user2: UserWithId,
-  preferenceType: PreferenceType
+  preferenceType: PreferenceType,
 ): Promise<LikedTracksQueryResponse> => {
   const likedTrackThreshold = 3;
-  const limit = 50;
+  const limit = MAX_TRACKS_PER_PLAYLIST;
 
   switch (preferenceType) {
     case "BOTH":

--- a/src/music/playlists/playlists.service.ts
+++ b/src/music/playlists/playlists.service.ts
@@ -45,7 +45,7 @@ type LikedTracksQueryResponse = {
 export async function getPlaylist(
   user1: UserWithId,
   user2: UserWithId,
-  preferenceType: PreferenceType,
+  preferenceType: PreferenceType
 ): Promise<Playlist> {
   const key = PlaylistCache.createKey([user1.id, user2.id], preferenceType);
   const cachedPlaylist = playlistCache.get(key);
@@ -56,7 +56,7 @@ export async function getPlaylist(
 
   const alternativeKey = PlaylistCache.createKey(
     [user2.id, user1.id],
-    reversePreferenceType(preferenceType),
+    reversePreferenceType(preferenceType)
   );
   const cachedPlaylistInverse = playlistCache.get(alternativeKey);
   if (cachedPlaylistInverse) {
@@ -66,7 +66,7 @@ export async function getPlaylist(
   const tracksMatchingPreferenceType = await getTrackIdsByPreferenceType(
     user1,
     user2,
-    preferenceType,
+    preferenceType
   );
 
   const tracks = (
@@ -112,7 +112,7 @@ export async function getPlaylist(
  */
 export async function preLoadAllPlaylists(
   user1: UserWithId,
-  user2: UserWithId,
+  user2: UserWithId
 ): Promise<void> {
   const preferenceTypes: PreferenceType[] = [
     "BOTH",
@@ -120,14 +120,11 @@ export async function preLoadAllPlaylists(
     "USER2-ONLY",
   ];
 
-  console.time(`Preloading playlists for ${user1.id} and ${user2.id}`);
   return Promise.all(
     preferenceTypes.map(async (preferenceType) => {
       await getPlaylist(user1, user2, preferenceType);
-    }),
-  ).then(() => {
-    console.timeEnd(`Preloading playlists for ${user1.id} and ${user2.id}`);
-  }); // Do nothing. The .then() is necessary to return a Promise<void> instead of Promise<void[]>
+    })
+  ).then(() => {}); // Do nothing. The .then() is necessary to return a Promise<void> instead of Promise<void[]>
 }
 
 /**
@@ -146,7 +143,7 @@ export async function preLoadAllPlaylists(
 const getTrackIdsByPreferenceType = async (
   user1: UserWithId,
   user2: UserWithId,
-  preferenceType: PreferenceType,
+  preferenceType: PreferenceType
 ): Promise<LikedTracksQueryResponse> => {
   const likedTrackThreshold = 3;
   const limit = MAX_TRACKS_PER_PLAYLIST;

--- a/src/music/playlists/playlists.types.ts
+++ b/src/music/playlists/playlists.types.ts
@@ -6,6 +6,17 @@ export const isValidPreferenceType = (type: string): type is PreferenceType => {
   return type === "USER1-ONLY" || type === "USER2-ONLY" || type === "BOTH";
 };
 
+export const reversePreferenceType = (type: string): PreferenceType => {
+  switch (type) {
+    case "USER1-ONLY":
+      return "USER2-ONLY";
+    case "USER2-ONLY":
+      return "USER1-ONLY";
+    default:
+      return "BOTH";
+  }
+};
+
 export type Playlist = {
   tracks: {
     items: TrackWithId[];

--- a/src/music/testingUtils/music.test.utils.ts
+++ b/src/music/testingUtils/music.test.utils.ts
@@ -1,5 +1,7 @@
 import * as MusicStorage from "../music.storage";
 import { Artist as PrismaArtist } from "@prisma/client";
+import { Playlist } from "../playlists/playlists.types";
+import { convertPrismaTrackAndArtistsToTrack } from "../music.utils";
 
 async function populateWithArtists(): Promise<PrismaArtist[]> {
   const artist1 = await MusicStorage.upsertArtist({
@@ -36,4 +38,15 @@ export async function populateWithTracks() {
   });
 
   return [track1, track2, track3];
+}
+
+export async function getExamplePlaylist(): Promise<Playlist> {
+  const prismaTracks = await populateWithTracks();
+  const tracks = prismaTracks.map((prismaTrack) => ({
+    ...convertPrismaTrackAndArtistsToTrack(prismaTrack, prismaTrack.artists),
+  }));
+
+  return {
+    tracks: { items: tracks },
+  };
 }

--- a/src/routes/index.router.ts
+++ b/src/routes/index.router.ts
@@ -4,6 +4,7 @@ import { getCurrentUser } from "../auth/auth.utils";
 import * as UserService from "../users/users.service";
 import * as SpotifyService from "../spotify/spotify.service";
 import { getSpotifyAccessTokenForSessionId } from "../spotify/spotify.storage";
+import { preLoadAllPlaylists } from "../music/playlists/playlists.service";
 
 import { SpotifyAccessToken } from "../auth/auth.types";
 import { isValidPreferenceType } from "../music/playlists/playlists.types";
@@ -100,6 +101,10 @@ indexRouter.get("/taste-comparison", async (req: Request, res: Response) => {
   spotifyLoginUrl += "?" + params.toString();
 
   if (user1 && user2) {
+    // request all possible playlists for these users
+    preLoadAllPlaylists(user1, user2);
+
+    // render the comparison page
     res.render("taste-comparison", {
       secondsToTimeFormat: secondsToTimeFormat,
       user1,


### PR DESCRIPTION
# Eagerly Generate Playlist and Store in a Cache

For background, see issue #25. The TLDR is that playlists are taking a long time to load.

# Features
## 🆕 Class - `PlaylistCache` - Stores entire playlists
- `function createPlaylistKey(users: [number, number], preferenceType: PreferenceType): string`

### Dependency - [`lru-cache`](https://www.npmjs.com/package/lru-cache)
This library looks well supported.

- Weekly Downloads - 192,121,185 
- Last Updated - One month ago 
- Documentation Quality - High
- Dependencies - 0

## 🆕 Functionality - `Playlist Service` looks for cached playlists before generating a new one

### Highlight - It looks for both the requested playlist and the inverse playlist

When a playlist is requested,

1) Look for a playlist the fits the exact parameters
2) Look for a playlist that fits the inverse parameters
- Example
  - Requested Params
    - User 1 - id: 1
    - User 2 - id: 2
    - Preference - USER1-ONLY  
  - Inverse
    - User 1 - id: 2 
    - User 2 - id: 1
    - Preference - USER2-ONLY
3) Generate Playlist 

![image](https://github.com/adambechtold/taste-explorer/assets/22563063/92505486-6ba3-4ed7-95bf-887a32cc8c57)

# Impact - The site appears 10-20x faster
- Request Time without Pre-cache
  - Median - 1.2s
  - 90th percentile - 2.0s
  - 99th percentile - 4.5s
- Request Time with Pre-cache
  - Median - 150ms
  - 90th percentile - 200ms
  - 99th percentile - 250ms

## Caveat - No speed up provided if the pre-load has not completed

### Approach for Future Optimization - Cache the pending preload function and return it 
The preload call already kicks off 3 playlist generation calls. We can store those pending functions in a cache. If those playlists are requested while the calls are pending, we can add some kind of `callback` to the pending function so that just wait for the previous calls to finish, rather than kick off new requests.

## Benchmarks are approximate
These numbers are approximate, based on informal benchmarking.

- Median - What I saw most often
- 90th percentile - Numbers I saw a few times during testing
- 99th percentile - The highest number I saw